### PR TITLE
update docker-composer.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     image: quay.io/coreos/etcd
     command:  etcd
     volumes:
-      - /usr/share/ca-certificates/:/etc/ssl/certs
+      - /usr/local/etc/ssl/certs/:/etc/ssl/certs
     env_file: etcd.env
     networks:
       - galera


### PR DESCRIPTION
changed location of ssl certs as we are proposing to change from rancheros to default boot2docker version